### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile-linux.yml
+++ b/.github/workflows/compile-linux.yml
@@ -1,5 +1,9 @@
 name: Linux Build
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ main, version-* ]


### PR DESCRIPTION
Potential fix for [https://github.com/Darkbriks/liara-engine/security/code-scanning/3](https://github.com/Darkbriks/liara-engine/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow (e.g., uploading artifacts, downloading artifacts, and accessing repository contents), the following permissions are likely needed:
- `contents: read` for accessing repository files.
- `actions: write` for managing workflow artifacts.

The `permissions` block will be added at the root level, ensuring it applies to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
