### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -1,5 +1,9 @@
 name: Windows Build
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ main, version-* ]


### PR DESCRIPTION
Potential fix for [https://github.com/Darkbriks/liara-engine/security/code-scanning/1](https://github.com/Darkbriks/liara-engine/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily needs read access to repository contents and possibly write access for uploading artifacts. We will set `contents: read` and `actions: write` as a starting point. If additional permissions are required, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
